### PR TITLE
[MMB] Add IAP auth to check_server_version

### DIFF
--- a/MMB_DOCUMENTATION.md
+++ b/MMB_DOCUMENTATION.md
@@ -210,6 +210,33 @@ After step 2, a PR is opened: `release-prep/3.4.25` → `release`.
 
 **CI trigger:** `.github/workflows/mmb-python-tests.yaml` runs on pull requests that touch Python source, tests, `pyproject.toml`, `Dockerfile`, etc. A typical upstream merge PR will satisfy these path filters.
 
+**IAP and client auth (check on every upstream merge)**
+
+When upstream touches client or connection code, scan the merge diff for:
+
+1. **`src/prefect/_internal/version_checking.py`** — Must still apply `IAPAuth` when `[api.iap] enabled` (mirror `get_client()`). Upstream may rewrite this module (Prefect 3.7+ added it); re-apply the `[MMB]` patch if conflict resolution dropped IAP.
+2. **`src/prefect/client/orchestration/__init__.py`** — `get_client()` must still set `httpx_settings["auth"] = IAPAuth()` when IAP enabled.
+3. **`src/prefect/_internal/websockets.py`** — Must still inject IAP headers via `IAPTokenManager` when IAP enabled.
+4. **`src/prefect/client/iap_auth.py`** — MMB-specific; should not be deleted by merge. If upstream adds their own IAP support, reconcile rather than drop.
+5. **New standalone HTTP to the API** — Grep the PR diff for `httpx.AsyncClient(` / `httpx.Client(` combined with `/admin/version` or `PREFECT_API_URL`. Any new path must use `get_client()` or copy the IAP guard from `get_client()`. Today only `version_checking.py` is the exception.
+6. **New WebSocket clients** — Must use `websocket_connect()` from `_internal/websockets.py`, not raw `websockets.connect()`.
+7. **Settings** — `[api.iap]` keys in `src/prefect/settings/models/api.py` must remain; upstream renames of env vars need MMB profile updates.
+
+Quick grep during PR review (copy-paste):
+
+```bash
+# After resolving merge conflicts locally on release-prep/X.Y.Z:
+git diff release...HEAD -- 'src/prefect/_internal/version_checking.py' \
+  'src/prefect/client/orchestration/__init__.py' \
+  'src/prefect/_internal/websockets.py' 'src/prefect/client/iap_auth.py'
+
+rg 'httpx\.(AsyncClient|Client)\(' src/prefect/_internal/version_checking.py \
+  src/prefect/client/ src/prefect/events/ src/prefect/logging/
+
+uv run pytest tests/_internal/test_version_checking.py \
+  tests/client/test_prefect_client.py -k "CheckServerVersion or version_check" -x
+```
+
 3. Merge the PR when green
 
 The `release` branch now contains upstream changes plus all MMB customisations. Delete `release-prep/3.4.25` after merge.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,6 +245,7 @@ default-version = "3.6.24+nogit"
 
 [tool.versioningit.vcs]
 match = ["[0-9]*.[0-9]*.[0-9]*", "[0-9]*.[0-9]*.[0-9]*.dev[0-9]*"]
+exclude = ["*-mmb"]
 # Dependabot clones with `--no-tags --depth 1`, so .git exists but
 # `git describe` finds no tags.  versioningit then uses default-tag as the
 # base version.  Keep this above the highest in-repo prefect>= floor

--- a/src/prefect/_internal/version_checking.py
+++ b/src/prefect/_internal/version_checking.py
@@ -147,14 +147,44 @@ async def check_server_version(
     if headers:
         httpx_kwargs["headers"] = headers
 
+    if settings.api.iap.enabled:
+        try:
+            from prefect.client.iap_auth import IAPAuth
+        except ImportError:
+            raise ImportError(
+                "IAP authentication is not available. Please install the prefect "
+                "(or prefect-client) package with the 'gcp-iap' extra."
+            ) from None
+        httpx_kwargs["auth"] = IAPAuth(
+            auth_header_name=settings.api.iap.auth_header_name,
+        )
+
     try:
         async with httpx.AsyncClient(**httpx_kwargs) as http_client:  # type: ignore[arg-type]
             response = await http_client.get(f"{api_url}/admin/version")
             response.raise_for_status()
             api_version_str: str = response.json()
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code in (401, 403):
+            if raise_on_error:
+                raise
+            logger.debug(
+                "Unable to check server version at %s: %s",
+                _sanitize_url(api_url),
+                e,
+            )
+            return
+        if raise_on_error:
+            raise RuntimeError(
+                f"Failed to reach API at {_sanitize_url(api_url)}"
+            ) from e
+        logger.debug(
+            "Unable to check server version at %s: %s",
+            _sanitize_url(api_url),
+            e,
+        )
+        return
     except Exception as e:
-        if "Unauthorized" in str(e):
-            raise
         if raise_on_error:
             raise RuntimeError(
                 f"Failed to reach API at {_sanitize_url(api_url)}"

--- a/src/prefect/settings/models/client.py
+++ b/src/prefect/settings/models/client.py
@@ -104,7 +104,10 @@ class ClientSettings(PrefectBaseSettings):
         When disabled, the client will skip the call to /admin/version that
         normally runs once per client context entry.  This is useful for worker
         subprocesses that inherit a known-compatible server configuration and
-        do not need to repeat the version handshake.
+        do not need to repeat the version handshake.  May be required on
+        IAP-protected deployments running builds before IAP was added to the
+        version check; prefer upgrading to a release that includes IAP-aware
+        version checking.
         """,
     )
 

--- a/tests/_internal/test_version_checking.py
+++ b/tests/_internal/test_version_checking.py
@@ -1,0 +1,206 @@
+import builtins
+import logging
+import sys
+import types
+from typing import AsyncGenerator, Generator
+
+import httpx
+import pytest
+import respx
+
+import prefect
+from prefect._internal.version_checking import (
+    _clear_api_version_check_cache,
+    check_server_version,
+)
+from prefect.settings import (
+    PREFECT_API_AUTH_STRING,
+    PREFECT_API_IAP_AUTH_HEADER_NAME,
+    PREFECT_API_IAP_ENABLED,
+    PREFECT_CLIENT_SERVER_VERSION_CHECK_ENABLED,
+    temporary_settings,
+)
+
+API_URL = "http://fake-server:4200/api"
+VERSION_URL = f"{API_URL}/admin/version"
+VALID_VERSION = "3.7.2"
+
+
+class MockIAPAuth(httpx.Auth):
+    """Minimal IAP auth mock that adds a bearer token header without GCP calls."""
+
+    def __init__(self, auth_header_name: str | None = None) -> None:
+        self.auth_header_name = auth_header_name or "Authorization"
+
+    def sync_auth_flow(
+        self, request: httpx.Request
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        request.headers[self.auth_header_name] = "Bearer mock-token"
+        yield request
+
+    async def async_auth_flow(
+        self, request: httpx.Request
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        request.headers[self.auth_header_name] = "Bearer mock-token"
+        yield request
+
+
+@pytest.fixture(autouse=True)
+def clear_api_version_check_cache():
+    _clear_api_version_check_cache()
+    yield
+    _clear_api_version_check_cache()
+
+
+@pytest.fixture(autouse=True)
+def pep440_client_version(monkeypatch):
+    """Use a PEP 440-compliant version so packaging.version.parse succeeds."""
+    monkeypatch.setattr(prefect, "__version__", VALID_VERSION)
+
+
+@pytest.fixture
+def mock_iap_auth(monkeypatch):
+    fake_iap_auth = types.ModuleType("prefect.client.iap_auth")
+    fake_iap_auth.IAPAuth = MockIAPAuth
+    monkeypatch.setitem(sys.modules, "prefect.client.iap_auth", fake_iap_auth)
+
+
+class TestCheckServerVersionIAP:
+    async def test_iap_header_included_when_enabled(self, mock_iap_auth):
+        with temporary_settings(
+            {
+                PREFECT_CLIENT_SERVER_VERSION_CHECK_ENABLED: True,
+                PREFECT_API_IAP_ENABLED: True,
+                PREFECT_API_IAP_AUTH_HEADER_NAME: "X-Serverless-Authorization",
+            }
+        ):
+            with respx.mock:
+                route = respx.get(VERSION_URL).mock(
+                    return_value=httpx.Response(200, json=VALID_VERSION)
+                )
+
+                await check_server_version(API_URL, logging.getLogger("test"))
+
+                assert route.called
+                request = route.calls[0].request
+                assert (
+                    request.headers["X-Serverless-Authorization"] == "Bearer mock-token"
+                )
+
+    async def test_iap_and_basic_auth_both_included(self, mock_iap_auth):
+        with temporary_settings(
+            {
+                PREFECT_CLIENT_SERVER_VERSION_CHECK_ENABLED: True,
+                PREFECT_API_IAP_ENABLED: True,
+                PREFECT_API_IAP_AUTH_HEADER_NAME: "X-Serverless-Authorization",
+                PREFECT_API_AUTH_STRING: "admin:password",
+            }
+        ):
+            with respx.mock:
+                route = respx.get(VERSION_URL).mock(
+                    return_value=httpx.Response(200, json=VALID_VERSION)
+                )
+
+                await check_server_version(API_URL, logging.getLogger("test"))
+
+                assert route.called
+                request = route.calls[0].request
+                assert (
+                    request.headers["X-Serverless-Authorization"] == "Bearer mock-token"
+                )
+                assert request.headers["Authorization"].startswith("Basic ")
+
+    async def test_no_iap_header_when_disabled(self):
+        with temporary_settings(
+            {
+                PREFECT_CLIENT_SERVER_VERSION_CHECK_ENABLED: True,
+                PREFECT_API_IAP_ENABLED: False,
+            }
+        ):
+            with respx.mock:
+                route = respx.get(VERSION_URL).mock(
+                    return_value=httpx.Response(200, json=VALID_VERSION)
+                )
+
+                await check_server_version(API_URL, logging.getLogger("test"))
+
+                assert route.called
+                request = route.calls[0].request
+                assert "X-Serverless-Authorization" not in request.headers
+
+    async def test_import_error_when_iap_enabled_but_unavailable(self, monkeypatch):
+        monkeypatch.delitem(sys.modules, "prefect.client.iap_auth", raising=False)
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "prefect.client.iap_auth":
+                raise ImportError("No module named 'prefect.client.iap_auth'")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+
+        with temporary_settings(
+            {
+                PREFECT_CLIENT_SERVER_VERSION_CHECK_ENABLED: True,
+                PREFECT_API_IAP_ENABLED: True,
+            }
+        ):
+            with pytest.raises(ImportError, match="gcp-iap"):
+                await check_server_version(API_URL, logging.getLogger("test"))
+
+
+class TestCheckServerVersionRaiseOnError:
+    async def test_raise_on_error_false_with_401_returns_silently(self, caplog):
+        with temporary_settings({PREFECT_CLIENT_SERVER_VERSION_CHECK_ENABLED: True}):
+            with respx.mock:
+                respx.get(VERSION_URL).mock(return_value=httpx.Response(401))
+
+                with caplog.at_level(logging.DEBUG):
+                    await check_server_version(
+                        API_URL,
+                        logging.getLogger("test"),
+                        raise_on_error=False,
+                    )
+
+                assert any(
+                    "Unable to check server version" in record.message
+                    for record in caplog.records
+                )
+
+    async def test_raise_on_error_true_with_401_raises(self):
+        with temporary_settings({PREFECT_CLIENT_SERVER_VERSION_CHECK_ENABLED: True}):
+            with respx.mock:
+                respx.get(VERSION_URL).mock(return_value=httpx.Response(401))
+
+                with pytest.raises(httpx.HTTPStatusError):
+                    await check_server_version(
+                        API_URL,
+                        logging.getLogger("test"),
+                        raise_on_error=True,
+                    )
+
+    async def test_raise_on_error_false_with_403_returns_silently(self):
+        with temporary_settings({PREFECT_CLIENT_SERVER_VERSION_CHECK_ENABLED: True}):
+            with respx.mock:
+                respx.get(VERSION_URL).mock(return_value=httpx.Response(403))
+
+                await check_server_version(
+                    API_URL,
+                    logging.getLogger("test"),
+                    raise_on_error=False,
+                )
+
+
+class TestCheckServerVersionCache:
+    async def test_second_call_uses_cache(self):
+        with temporary_settings({PREFECT_CLIENT_SERVER_VERSION_CHECK_ENABLED: True}):
+            with respx.mock:
+                route = respx.get(VERSION_URL).mock(
+                    return_value=httpx.Response(200, json=VALID_VERSION)
+                )
+
+                logger = logging.getLogger("test")
+                await check_server_version(API_URL, logger)
+                await check_server_version(API_URL, logger)
+
+                assert route.call_count == 1


### PR DESCRIPTION
## Summary

Fixes Cloud Run 401 failures during flow-run startup by applying IAP authentication to the standalone `/admin/version` probe in `check_server_version()`, matching `get_client()` behaviour. Also honours `raise_on_error=False` for 401/403 responses so events/logs clients degrade gracefully.

## Changes

- **`src/prefect/_internal/version_checking.py`** — Apply `IAPAuth` when `[api.iap] enabled`; handle 401/403 via `httpx.HTTPStatusError` instead of string matching on "Unauthorized"
- **`src/prefect/settings/models/client.py`** — Document `server_version_check_enabled` workaround for pre-fix builds
- **`MMB_DOCUMENTATION.md`** — Add upstream-merge IAP watchpoints checklist under Step 3

## Test plan

- [ ] `uv run pytest tests/client/test_prefect_client.py -k CheckServerVersion -x`
- [ ] Deploy `analytics-reports` demo job to dev Cloud Run without `server_version_check_enabled = false`
- [ ] Confirm flow-run passes startup and events/logs appear in UI


Made with [Cursor](https://cursor.com)