### PR TITLE
docs: require merge commits for release-prep PRs

### DIFF
--- a/MMB_DOCUMENTATION.md
+++ b/MMB_DOCUMENTATION.md
@@ -207,6 +207,11 @@ After step 2, a PR is opened: `release-prep/3.4.25` → `release`.
 
 1. Review the diff on GitHub
 2. Wait for **MMB - Unit tests** to pass
+3. Merge with a **merge commit** (`gh pr merge --merge`) — **never squash or rebase**
+
+Squash-merging a release-prep PR breaks upstream tag ancestry on `release`. Version
+resolution then falls back to older tags and may require `.postN` overrides. The
+local prep script already creates a proper merge commit; GitHub must preserve it.
 
 **CI trigger:** `.github/workflows/mmb-python-tests.yaml` runs on pull requests that touch Python source, tests, `pyproject.toml`, `Dockerfile`, etc. A typical upstream merge PR will satisfy these path filters.
 

--- a/docs/mmb-release-process.md
+++ b/docs/mmb-release-process.md
@@ -125,8 +125,20 @@ git commit -m "address review feedback for 3.4.25 merge"
 git push origin release-prep/3.4.25
 ```
 
-Once the PR is green, merge it. The `release` branch now contains the upstream
-changes plus all MMB customisations.
+Once the PR is green, merge it with a **merge commit** — never squash or rebase.
+Squash merges drop upstream tag ancestry, so `git describe` resolves wrong package
+versions during release (e.g. `prefect-gcp==0.6.18.post1` instead of `0.6.19`).
+
+```bash
+gh pr merge --merge   # correct
+# Do NOT use: gh pr merge --squash or --rebase
+```
+
+The `release-prep/<tag>` branch is merged locally with `git merge <tag>`, which
+creates a two-parent merge commit. GitHub must preserve that structure when
+landing the PR on `release`.
+
+The `release` branch now contains the upstream changes plus all MMB customisations.
 
 The `release-prep/<tag>` branch can be deleted after the PR is merged.
 

--- a/scripts/mmb-prepare-release.sh
+++ b/scripts/mmb-prepare-release.sh
@@ -167,7 +167,8 @@ branch, bringing in all upstream changes while preserving MMB customisations.
 ### Review checklist
 - [ ] Confirm the diff looks correct (upstream changes + no unintended modifications)
 - [ ] Verify integration package code is at the expected version
-- [ ] Merge when satisfied — then run **MMB - Release Packages** to publish
+- [ ] Merge with a **merge commit** (\`gh pr merge --merge\`) — do NOT squash or rebase
+- [ ] Then run **MMB - Release Packages** to publish
 EOF
     else
         cat <<EOF
@@ -185,7 +186,8 @@ branch, bringing in all upstream changes while preserving MMB customisations.
 ### Review checklist
 - [ ] Confirm the diff looks correct (upstream changes + no unintended modifications)
 - [ ] Verify integration package code is at the expected version
-- [ ] Merge when satisfied — then run **MMB - Release Packages** to publish
+- [ ] Merge with a **merge commit** (\`gh pr merge --merge\`) — do NOT squash or rebase
+- [ ] Then run **MMB - Release Packages** to publish
 EOF
     fi
 }
@@ -250,7 +252,7 @@ print_summary() {
     echo "Next steps:"
     echo "  1. Review the PR diff"
     echo "  2. Wait for mmb-python-tests CI to pass"
-    echo "  3. Merge the PR into release"
+    echo "  3. Merge the PR with a MERGE COMMIT (gh pr merge --merge). Do NOT squash."
     echo "  4. Dispatch MMB - Release Packages from GitHub Actions"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 }


### PR DESCRIPTION
Documents that release-prep PRs must be merged with `gh pr merge --merge`, not squash.

Made with [Cursor](https://cursor.com)