### PR TITLE
[MMB] Align core dependencies with upstream Prefect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,6 @@ dependencies = [
     "whenever>=0.7.3,<0.11.0; python_version>='3.13'",
     "semver>=3.0.4",
     "pluggy>=1.6.0",
-    "fakeredis<2.35.0",
-    "google-cloud-storage>=3.10.1",
-    "referencing>=0.37.0",
     "pydocket>=0.19.0",
 ]
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1413,20 +1413,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fakeredis"
-version = "2.34.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "redis" },
-    { name = "sortedcontainers" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/11/40/fd09efa66205eb32253d2b2ebc63537281384d2040f0a88bcd2289e120e4/fakeredis-2.34.1.tar.gz", hash = "sha256:4ff55606982972eecce3ab410e03d746c11fe5deda6381d913641fbd8865ea9b", size = 177315, upload-time = "2026-02-25T13:17:51.315Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/b5/82f89307d0d769cd9bf46a54fb9136be08e4e57c5570ae421db4c9a2ba62/fakeredis-2.34.1-py3-none-any.whl", hash = "sha256:0107ec99d48913e7eec2a5e3e2403d1bd5f8aa6489d1a634571b975289c48f12", size = 122160, upload-time = "2026-02-25T13:17:49.701Z" },
-]
-
-[[package]]
 name = "fastapi"
 version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4025,10 +4011,8 @@ dependencies = [
     { name = "dateparser" },
     { name = "docker" },
     { name = "exceptiongroup" },
-    { name = "fakeredis" },
     { name = "fastapi" },
     { name = "fsspec" },
-    { name = "google-cloud-storage" },
     { name = "graphviz" },
     { name = "griffe" },
     { name = "httpcore" },
@@ -4055,7 +4039,6 @@ dependencies = [
     { name = "pytz" },
     { name = "pyyaml" },
     { name = "readchar" },
-    { name = "referencing" },
     { name = "rfc3339-validator" },
     { name = "rich" },
     { name = "ruamel-yaml" },
@@ -4235,12 +4218,10 @@ requires-dist = [
     { name = "dateparser", specifier = ">=1.1.1,<2.0.0" },
     { name = "docker", specifier = ">=4.0,<8.0" },
     { name = "exceptiongroup", specifier = ">=1.0.0" },
-    { name = "fakeredis", specifier = "<2.35.0" },
     { name = "fastapi", specifier = ">=0.111.0,<1.0.0" },
     { name = "fsspec", specifier = ">=2022.5.0" },
     { name = "google-auth", marker = "extra == 'gcp-iap'", specifier = ">=2.40.3" },
     { name = "google-cloud-secret-manager", marker = "extra == 'gcp-iap'", specifier = ">=2.24.0" },
-    { name = "google-cloud-storage", specifier = ">=3.10.1" },
     { name = "graphviz", specifier = ">=0.20.1" },
     { name = "griffe", specifier = ">=0.49.0,<3.0.0" },
     { name = "httpcore", specifier = ">=1.0.5,<2.0.0" },
@@ -4292,7 +4273,6 @@ requires-dist = [
     { name = "pytz", specifier = ">=2021.1,<2027" },
     { name = "pyyaml", specifier = ">=5.4.1,<7.0.0" },
     { name = "readchar", specifier = ">=4.0.0,<5.0.0" },
-    { name = "referencing", specifier = ">=0.37.0" },
     { name = "rfc3339-validator", specifier = ">=0.1.4,<0.2.0" },
     { name = "rich", specifier = ">=11.0,<16.0" },
     { name = "ruamel-yaml", specifier = ">=0.17.0" },


### PR DESCRIPTION
Removes accidental core deps (fakeredis, google-cloud-storage, referencing) to match PrefectHQ main. Core-only MMB patch for 3.7.3 line.

Made with [Cursor](https://cursor.com)