### PR TITLE
ANALYS-2755: Bump actions/checkout to v7

### DIFF
--- a/.github/workflows/mmb-python-tests.yaml
+++ b/.github/workflows/mmb-python-tests.yaml
@@ -151,7 +151,7 @@ jobs:
       - name: Display current test matrix
         run: echo '${{ toJSON(matrix) }}'
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -194,7 +194,7 @@ jobs:
     name: Verify test selection coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -256,7 +256,7 @@ jobs:
       - name: Display current test matrix
         run: echo '${{ toJSON(matrix) }}'
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -347,7 +347,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/mmb-release-packages.yaml
+++ b/.github/workflows/mmb-release-packages.yaml
@@ -79,7 +79,7 @@ jobs:
       script_exit_code: ${{ steps.python_release.outputs.script_exit_code }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ env.PREFECT_REPO_PAT }}
@@ -233,7 +233,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -358,7 +358,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@v7
 
       - name: Create overall summary
         env:

--- a/.github/workflows/mmb-sync-main.yaml
+++ b/.github/workflows/mmb-sync-main.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ env.PREFECT_REPO_PAT }}


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` refs at v4 or lower to v7

## Jira
https://medmera.atlassian.net/browse/ANALYS-2755

## Test plan
- [ ] CI workflows pass

Made with [Cursor](https://cursor.com)